### PR TITLE
Check permission when link to other route which has same component

### DIFF
--- a/lib/components/AuthorizedComponent.react.js
+++ b/lib/components/AuthorizedComponent.react.js
@@ -3,6 +3,7 @@ import * as roleMatcher from '../utils/roleMatcher';
 
 class AuthorizedComponent extends React.Component {
   static propTypes = {
+    location: PropTypes.object.isRequired,
     routes: PropTypes.array.isRequired
   };
 
@@ -24,8 +25,22 @@ class AuthorizedComponent extends React.Component {
     // validate properties first
     this.validate();
 
+    this.checkRoles(this.props);
+  }
+
+  componentWillUpdate(nextProps) {
+    // skip if change props in same route
+    if (this.props.location.pathname === nextProps.location.pathname) {
+      return;
+    }
+
+    this.checkRoles(nextProps);
+  }
+
+  // check permission
+  checkRoles(props) {
     // when you use react-router, `routes` should be set
-    const { routes } = this.props;
+    const { routes } = props;
 
     // check roles
     const routeRoles = roleMatcher.getFlatterRoles(routes);


### PR DESCRIPTION
IMHO, #2 will be caused when link to other route which has same component.
`componentWillMount` is NOT triggered when transition between same components.

This PR check permission when when link to other route which has same component also.