### PR TITLE
Allow undefined notAuthorizedPath if handleUnauthorizedRole is overridden

### DIFF
--- a/lib/components/AuthorizedComponent.react.js
+++ b/lib/components/AuthorizedComponent.react.js
@@ -38,6 +38,10 @@ class AuthorizedComponent extends React.Component {
   // @param routeRoles roles defending the route requested
   // @param userRoles roles of the user accessing the component
   handleUnauthorizedRole(routeRoles, userRoles) {
+    if (typeof this.notAuthorizedPath === 'undefined') {
+      throw new Error('AuthorizedComponent: No not authorized path defined! Please define it in the constructor of your component.');
+    }
+
     const { router } = this.context;
     router.push(this.notAuthorizedPath);
   }
@@ -46,10 +50,6 @@ class AuthorizedComponent extends React.Component {
   validate() {
     if (typeof this.userRoles === 'undefined') {
       throw new Error('AuthorizedComponent: No user roles defined! Please define them in the constructor of your component.');
-    }
-
-    if (typeof this.notAuthorizedPath === 'undefined') {
-      throw new Error('AuthorizedComponent: No not authorized path defined! Please define it in the constructor of your component.');
     }
   }
 }


### PR DESCRIPTION
`notAuthorizedPath` isn't used, if user has been overridden `handleUnauthorizedRole` and custom handler doesn't call `super#handleUnauthorizedRole`.